### PR TITLE
Feat/likes

### DIFF
--- a/src/main/java/com/spring/blackcat/common/security/config/SecurityConfig.java
+++ b/src/main/java/com/spring/blackcat/common/security/config/SecurityConfig.java
@@ -22,8 +22,7 @@ import org.springframework.web.filter.CorsFilter;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.springframework.http.HttpMethod.OPTIONS;
-import static org.springframework.http.HttpMethod.POST;
+import static org.springframework.http.HttpMethod.*;
 
 @EnableWebSecurity
 @RequiredArgsConstructor
@@ -62,6 +61,9 @@ public class SecurityConfig {
         return http.antMatcher("/**")
                 .authorizeRequests()
                 .mvcMatchers(OPTIONS, "/**").permitAll() // Preflight Request 허용해주기
+                .antMatchers(GET, "/api/v1/categories").permitAll()
+                .antMatchers(GET, "/api/v1/tattoos").permitAll()
+                .antMatchers(GET, "/api/v1/tattoos/categories/**").permitAll()
                 .antMatchers(POST, "/init").access("hasRole('ADMIN')")
                 .antMatchers(POST, "/api/v1/magazines").access("hasRole('ADMIN')")
                 .antMatchers(POST, "/api/v1/tattoos").access("hasRole('TATTOOIST') or hasRole('ADMIN')")

--- a/src/main/java/com/spring/blackcat/likes/LikesController.java
+++ b/src/main/java/com/spring/blackcat/likes/LikesController.java
@@ -3,6 +3,7 @@ package com.spring.blackcat.likes;
 import com.spring.blackcat.common.response.ResponseDto;
 import com.spring.blackcat.common.response.ResponseUtil;
 import com.spring.blackcat.common.security.interceptor.UserId;
+import com.spring.blackcat.likes.dto.LikesMultiReqDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -36,6 +37,25 @@ public class LikesController {
             @PathVariable("postId") Long postId,
             @UserId Long userId) {
         return ResponseUtil.SUCCESS("게시물 좋아요 해제 성공", likesService.likesOff(postId, userId));
+    }
+
+    @PostMapping("/posts")
+    public ResponseDto multipleLikesOn(
+            @RequestBody LikesMultiReqDto multiReqDto,
+            @UserId Long userId) {
+        return ResponseUtil.SUCCESS("게시물들 좋아요 설정 성공", likesService.multipleLikesOn(multiReqDto.getPostIds(), userId));
+    }
+
+    @DeleteMapping("/posts")
+    public ResponseDto multipleLikesOff(
+            @RequestBody LikesMultiReqDto multiReqDto,
+            @UserId Long userId) {
+        return ResponseUtil.SUCCESS("게시물들 좋아요 해제 성공", likesService.multipleLikesOff(multiReqDto.getPostIds(), userId));
+    }
+
+    @GetMapping("posts/{postId}/count")
+    public ResponseDto likesCount(@PathVariable Long postId) {
+        return ResponseUtil.SUCCESS("게시물 좋아요 수 조회 성공", likesService.countByPostId(postId));
     }
 
     @GetMapping("posts/{postId}/users")

--- a/src/main/java/com/spring/blackcat/likes/LikesRepository.java
+++ b/src/main/java/com/spring/blackcat/likes/LikesRepository.java
@@ -2,9 +2,14 @@ package com.spring.blackcat.likes;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface LikesRepository extends JpaRepository<Likes, Long>, LikesRepositoryCustom {
 
+    Long countByPostId(Long postId);
+
     Optional<Likes> findByPostIdAndUserId(Long postId, Long userId);
+
+    List<Likes> findByPostIdInAndUserId(List<Long> postIds, Long userId);
 }

--- a/src/main/java/com/spring/blackcat/likes/LikesService.java
+++ b/src/main/java/com/spring/blackcat/likes/LikesService.java
@@ -6,6 +6,8 @@ import com.spring.blackcat.likes.dto.LikesUserResDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
+
 public interface LikesService {
 
     LikesStatusResDto isLikedThisPost(Long postId, Long userId);
@@ -13,6 +15,12 @@ public interface LikesService {
     LikesStatusResDto likesOn(Long postId, Long userId);
 
     LikesStatusResDto likesOff(Long postId, Long userId);
+
+    LikesStatusResDto multipleLikesOn(List<Long> postIds, Long userId);
+
+    LikesStatusResDto multipleLikesOff(List<Long> postIds, Long userId);
+
+    Long countByPostId(Long postId);
 
     Page<LikesUserResDto> findLikesUsersByPostId(Pageable pageable, Long postId);
 

--- a/src/main/java/com/spring/blackcat/likes/dto/LikesMultiReqDto.java
+++ b/src/main/java/com/spring/blackcat/likes/dto/LikesMultiReqDto.java
@@ -1,0 +1,11 @@
+package com.spring.blackcat.likes.dto;
+
+import lombok.Data;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+public class LikesMultiReqDto {
+    List<Long> postIds = new ArrayList<>();
+}

--- a/src/main/java/com/spring/blackcat/post/PostRepository.java
+++ b/src/main/java/com/spring/blackcat/post/PostRepository.java
@@ -2,5 +2,9 @@ package com.spring.blackcat.post;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface PostRepository extends JpaRepository<Post, Long> {
+
+    List<Post> findByIdIn(List<Long> postIds);
 }


### PR DESCRIPTION
## 👉🏻 PR 내용 (어떤 부분이 달라졌는지 알려주세요!)

- 전체 카테고리 조회, 전체 타투 조회, 카테고리별 타투 조회 API 인증 제거
- 여러 개의 좋아요 등록 및 삭제 API 추가
- 좋아요 개수 조회 API 추가

## 👉🏻 중점적으로 봐주었으면 하는 부분

- 전체 타투 조회, 카테고리별 타투 조회 API > 인증 제거 관련 Controller userId 파라미터 확인 필요
