### PR TITLE
Fix: Fix tattoo apis to get multiple category id

### DIFF
--- a/src/main/java/com/spring/blackcat/category/Category.java
+++ b/src/main/java/com/spring/blackcat/category/Category.java
@@ -1,7 +1,7 @@
 package com.spring.blackcat.category;
 
+import com.spring.blackcat.categoryPost.CategoryPost;
 import com.spring.blackcat.common.BaseTimeEntity;
-import com.spring.blackcat.tattoo.Tattoo;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -35,7 +35,7 @@ public class Category extends BaseTimeEntity {
     private List<Category> children = new ArrayList<>();
 
     @OneToMany(mappedBy = "category", cascade = ALL)
-    private List<Tattoo> tattoos = new ArrayList<>();
+    private List<CategoryPost> categoryPosts = new ArrayList<>();
 
     private Long registerId;
     private Long modifierId;

--- a/src/main/java/com/spring/blackcat/category/CategoryRepository.java
+++ b/src/main/java/com/spring/blackcat/category/CategoryRepository.java
@@ -5,6 +5,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface CategoryRepository extends JpaRepository<Category, Long> {
-    
+
     Optional<Category> findByName(String name);
+
+    Optional<Category> findById(Long id);
 }

--- a/src/main/java/com/spring/blackcat/category/dto/CategoryResDto.java
+++ b/src/main/java/com/spring/blackcat/category/dto/CategoryResDto.java
@@ -15,6 +15,7 @@ public class CategoryResDto {
     public CategoryResDto(Category category) {
         this.id = category.getId();
         this.name = category.getName();
-        this.count = category.getTattoos().size();
+        //TODO 포스트와 카테고리 사이 관계 테이블 생성으로 인한 변경 필요
+//        this.count = category.getTattoos().size();
     }
 }

--- a/src/main/java/com/spring/blackcat/categoryPost/CategoryPost.java
+++ b/src/main/java/com/spring/blackcat/categoryPost/CategoryPost.java
@@ -1,0 +1,35 @@
+package com.spring.blackcat.categoryPost;
+
+import com.spring.blackcat.category.Category;
+import com.spring.blackcat.common.BaseTimeEntity;
+import com.spring.blackcat.post.Post;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+import static javax.persistence.FetchType.LAZY;
+import static javax.persistence.GenerationType.IDENTITY;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CategoryPost extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "category_post_id")
+    private Long id;
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "category_id")
+    private Category category;
+
+    public CategoryPost(Post post, Category category) {
+        this.post = post;
+        this.category = category;
+    }
+}

--- a/src/main/java/com/spring/blackcat/categoryPost/CategoryPostRepository.java
+++ b/src/main/java/com/spring/blackcat/categoryPost/CategoryPostRepository.java
@@ -1,0 +1,11 @@
+package com.spring.blackcat.categoryPost;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface CategoryPostRepository extends JpaRepository<CategoryPost, Long> {
+    List<CategoryPost> findByPostId(Long postId);
+
+    void deleteByPostId(Long postId);
+}

--- a/src/main/java/com/spring/blackcat/common/exception/ErrorInfo.java
+++ b/src/main/java/com/spring/blackcat/common/exception/ErrorInfo.java
@@ -26,7 +26,10 @@ public enum ErrorInfo {
     ADDRESS_NOT_FOUND_EXCEPTION(400, 1015, "존재하지 않은 주소입니다."),
     POST_NOT_FOUND_EXCEPTION(400, 1016, "존재하지 않는 게시물입니다."),
 
-    ALREADY_TATTOOIST_EXCEPTION(400, 1017, "이미 타투이스트로 승급한 사용자입니다.");
+    ALREADY_TATTOOIST_EXCEPTION(400, 1017, "이미 타투이스트로 승급한 사용자입니다."),
+
+    PROFILE_NOT_FOUND_EXCEPTION(400, 1017, "존재하지 않는 프로필 입니다."),
+    ;
 
     private final boolean success = false;
     private int statusCode;

--- a/src/main/java/com/spring/blackcat/common/exception/custom/ProfileNotFoundException.java
+++ b/src/main/java/com/spring/blackcat/common/exception/custom/ProfileNotFoundException.java
@@ -1,0 +1,14 @@
+package com.spring.blackcat.common.exception.custom;
+
+import com.spring.blackcat.common.exception.ErrorInfo;
+import lombok.Getter;
+
+@Getter
+public class ProfileNotFoundException extends CustomException {
+    private ErrorInfo errorInfo;
+
+    public ProfileNotFoundException(String message, ErrorInfo errorInfo) {
+        super(message);
+        this.errorInfo = errorInfo;
+    }
+}

--- a/src/main/java/com/spring/blackcat/common/init/InitService.java
+++ b/src/main/java/com/spring/blackcat/common/init/InitService.java
@@ -293,7 +293,7 @@ class InitService {
         Address address = addressRepository.findById(1L).get();
         User user = this.userRepository.findById(1L).get();
 
-        return new Tattoo(name, description, price, category, tattooType, user);
+        return new Tattoo(name, description, price, tattooType, user);
     }
 
     private Magazine createMagazine(String title) {

--- a/src/main/java/com/spring/blackcat/post/Post.java
+++ b/src/main/java/com/spring/blackcat/post/Post.java
@@ -1,5 +1,6 @@
 package com.spring.blackcat.post;
 
+import com.spring.blackcat.categoryPost.CategoryPost;
 import com.spring.blackcat.common.BaseTimeEntity;
 import com.spring.blackcat.common.code.PostType;
 import com.spring.blackcat.likes.Likes;
@@ -35,6 +36,9 @@ public abstract class Post extends BaseTimeEntity {
     @OneToMany(mappedBy = "post", cascade = ALL, orphanRemoval = true)
     private List<Likes> likes = new ArrayList<>();
 
+    @OneToMany(mappedBy = "post", cascade = ALL)
+    private List<CategoryPost> categoryPosts = new ArrayList<>();
+
     @Enumerated(EnumType.STRING)
     @Column(insertable = false, updatable = false)
     private PostType postType;
@@ -60,5 +64,9 @@ public abstract class Post extends BaseTimeEntity {
 
     protected void setTitle(String title) {
         this.title = title;
+    }
+
+    public void addCategoryPost(CategoryPost categoryPost) {
+        this.categoryPosts.add(categoryPost);
     }
 }

--- a/src/main/java/com/spring/blackcat/post/PostRepository.java
+++ b/src/main/java/com/spring/blackcat/post/PostRepository.java
@@ -3,8 +3,11 @@ package com.spring.blackcat.post;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
 
     List<Post> findByIdIn(List<Long> postIds);
+
+    Optional<Post> findById(Long id);
 }

--- a/src/main/java/com/spring/blackcat/profile/ProfileController.java
+++ b/src/main/java/com/spring/blackcat/profile/ProfileController.java
@@ -16,15 +16,15 @@ import java.util.List;
 public class ProfileController {
     private final ProfileService profileService;
 
-    @PostMapping("/tattooists")
+    @PostMapping()
     public ResponseDto upsertTattooistProfile(@RequestPart(value = "profileInfo") UpsertProfileReqDto upsertProfileReqDto,
                                               @RequestPart(value = "images", required = false) List<MultipartFile> images,
                                               @UserId Long userId) {
         return ResponseUtil.SUCCESS("타투이스트 프로필 등록 성공", this.profileService.upsertTattooistProfile(userId, upsertProfileReqDto, images));
     }
 
-    @GetMapping("/tattooists/{tattooistId}")
-    public ResponseDto getTattooistProfile(@PathVariable Long tattooistId) {
-        return ResponseUtil.SUCCESS("타투이스트 프로필 조회 성공", this.profileService.getTattooistProfile(tattooistId));
+    @GetMapping("/{profileId}")
+    public ResponseDto getTattooistProfile(@PathVariable Long profileId) {
+        return ResponseUtil.SUCCESS("타투이스트 프로필 조회 성공", this.profileService.getTattooistProfile(profileId));
     }
 }

--- a/src/main/java/com/spring/blackcat/profile/ProfileRepository.java
+++ b/src/main/java/com/spring/blackcat/profile/ProfileRepository.java
@@ -6,4 +6,6 @@ import java.util.Optional;
 
 public interface ProfileRepository extends JpaRepository<Profile, Long> {
     Optional<Profile> findByUserId(Long userId);
+
+    Optional<Profile> findById(Long id);
 }

--- a/src/main/java/com/spring/blackcat/profile/ProfileService.java
+++ b/src/main/java/com/spring/blackcat/profile/ProfileService.java
@@ -1,5 +1,6 @@
 package com.spring.blackcat.profile;
 
+import com.spring.blackcat.profile.dto.GetProfileResDto;
 import com.spring.blackcat.profile.dto.UpsertProfileReqDto;
 import com.spring.blackcat.profile.dto.UpsertProfileResDto;
 import org.springframework.web.multipart.MultipartFile;
@@ -9,5 +10,5 @@ import java.util.List;
 public interface ProfileService {
     UpsertProfileResDto upsertTattooistProfile(Long userId, UpsertProfileReqDto upsertProfileReqDto, List<MultipartFile> images);
 
-    UpsertProfileResDto getTattooistProfile(Long userId);
+    GetProfileResDto getTattooistProfile(Long profileId);
 }

--- a/src/main/java/com/spring/blackcat/profile/ProfileServiceImpl.java
+++ b/src/main/java/com/spring/blackcat/profile/ProfileServiceImpl.java
@@ -4,6 +4,7 @@ import com.spring.blackcat.common.code.ImageType;
 import com.spring.blackcat.common.exception.ErrorInfo;
 import com.spring.blackcat.common.exception.custom.UserNotFoundException;
 import com.spring.blackcat.image.ImageService;
+import com.spring.blackcat.profile.dto.GetProfileResDto;
 import com.spring.blackcat.profile.dto.UpsertProfileReqDto;
 import com.spring.blackcat.profile.dto.UpsertProfileResDto;
 import com.spring.blackcat.user.User;
@@ -28,18 +29,28 @@ public class ProfileServiceImpl implements ProfileService {
         User user = this.userRepository.findById(userId)
                 .orElseThrow(() -> new UserNotFoundException("존재하지 않는 사용자 입니다.", ErrorInfo.USER_NOT_FOUND_EXCEPTION));
 
+        Profile profile = updateProfile(userId, upsertProfileReqDto);
+
+        List<String> imageUrls = updateImages(upsertProfileReqDto, images, profile);
+
+        UpsertProfileResDto upsertProfileResDto = new UpsertProfileResDto(profile.getId(), profile.getIntroduce(), imageUrls);
+
+        return upsertProfileResDto;
+    }
+
+    private Profile updateProfile(Long userId, UpsertProfileReqDto upsertProfileReqDto) {
         Profile profile = this.profileRepository.findByUserId(userId).get();
         profile.updateProfile(upsertProfileReqDto.getIntroduce());
+        return profile;
+    }
 
+    private List<String> updateImages(UpsertProfileReqDto upsertProfileReqDto, List<MultipartFile> images, Profile profile) {
         deleteImages(upsertProfileReqDto.getDeleteImageUrls());
         if (images != null) {
             this.imageService.saveImage(ImageType.POST, profile.getId(), images);
         }
         List<String> imageUrls = this.imageService.getImageUrls(ImageType.POST, profile.getId());
-
-        UpsertProfileResDto upsertProfileResDto = new UpsertProfileResDto(profile.getIntroduce(), imageUrls);
-
-        return upsertProfileResDto;
+        return imageUrls;
     }
 
     private void deleteImages(List<String> imageUrls) {
@@ -47,14 +58,16 @@ public class ProfileServiceImpl implements ProfileService {
     }
 
     @Override
-    public UpsertProfileResDto getTattooistProfile(Long tattooistId) {
-        Profile profile = this.profileRepository.findByUserId(tattooistId)
-                .orElseThrow(() -> new UserNotFoundException("존재하지 않는 사용자 입니다.", ErrorInfo.USER_NOT_FOUND_EXCEPTION));
+    public GetProfileResDto getTattooistProfile(Long profileId) {
+        Profile profile = this.profileRepository.findById(profileId)
+                .orElseThrow(() -> new UserNotFoundException("존재하지 않는 프로필 입니다.", ErrorInfo.USER_NOT_FOUND_EXCEPTION));
 
         List<String> imageUrls = this.imageService.getImageUrls(ImageType.POST, profile.getId());
+        List<String> userImgUrls = this.imageService.getImageUrls(ImageType.USER, profile.getUser().getId());
 
-        UpsertProfileResDto upsertProfileResDto = new UpsertProfileResDto(profile.getIntroduce(), imageUrls);
+        GetProfileResDto getProfileResDto = new GetProfileResDto(profile.getId(), profile.getIntroduce(),
+                imageUrls, profile.getUser().getName(), profile.getUser().getAddress().getId(), userImgUrls);
 
-        return upsertProfileResDto;
+        return getProfileResDto;
     }
 }

--- a/src/main/java/com/spring/blackcat/profile/dto/GetProfileResDto.java
+++ b/src/main/java/com/spring/blackcat/profile/dto/GetProfileResDto.java
@@ -7,8 +7,11 @@ import java.util.List;
 
 @Data
 @AllArgsConstructor
-public class UpsertProfileResDto {
+public class GetProfileResDto {
     Long profileId;
     String introduce;
     List<String> imageUrls;
+    String userName;
+    Long addressId;
+    List<String> userImgUrls;
 }

--- a/src/main/java/com/spring/blackcat/tattoo/Tattoo.java
+++ b/src/main/java/com/spring/blackcat/tattoo/Tattoo.java
@@ -1,6 +1,5 @@
 package com.spring.blackcat.tattoo;
 
-import com.spring.blackcat.category.Category;
 import com.spring.blackcat.common.code.PostType;
 import com.spring.blackcat.common.code.TattooType;
 import com.spring.blackcat.post.Post;
@@ -10,8 +9,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
-
-import static javax.persistence.FetchType.LAZY;
 
 @Entity
 @Getter
@@ -24,46 +21,29 @@ public class Tattoo extends Post {
     @Column(name = "tattoo_description")
     private String description;
 
-    @ManyToOne(fetch = LAZY)
-    @JoinColumn(name = "category_id")
-    private Category category;
-
-//    @OneToOne(fetch = LAZY)
-//    @JoinColumn(name = "post_id")
-//    private Post post;
-
     @Enumerated(EnumType.STRING)
     private TattooType tattooType;
 
     public Tattoo(String title, String description, Long price,
-                  Category category, TattooType tattooType, User user) {
+                  TattooType tattooType, User user) {
         super(title, user);
         this.description = description;
         this.price = price;
-        this.category = category;
         this.tattooType = tattooType;
     }
 
     public Tattoo(Long id, String title, String description, Long price,
-                  Category category, TattooType tattooType, User user) {
+                  TattooType tattooType, User user) {
         super(id, title, user);
         this.description = description;
         this.price = price;
-        this.category = category;
         this.tattooType = tattooType;
     }
 
-    public void updateTattoo(String title, String description, Long price, Category category, TattooType tattooType) {
+    public void updateTattoo(String title, String description, Long price, TattooType tattooType) {
         this.setTitle(title);
         this.description = description;
         this.price = price;
-        this.changeCategory(category);
         this.tattooType = tattooType;
-    }
-
-    public void changeCategory(Category category) {
-        this.category.getTattoos().remove(this);
-        this.category = category;
-        category.getTattoos().add(this);
     }
 }

--- a/src/main/java/com/spring/blackcat/tattoo/TattooController.java
+++ b/src/main/java/com/spring/blackcat/tattoo/TattooController.java
@@ -53,7 +53,7 @@ public class TattooController {
 
     @PostMapping()
     public ResponseDto createTattoo(@RequestPart("tattooInfo") @Valid CreateTattooDto createTattooDto,
-                                    @RequestPart("images") List<MultipartFile> images,
+                                    @RequestPart(name = "images", required = true) List<MultipartFile> images,
                                     @UserId Long userId) {
         return ResponseUtil.SUCCESS("타투 생성 성공", this.tattooService.createTattoo(userId, createTattooDto, images));
     }
@@ -61,7 +61,7 @@ public class TattooController {
     @PatchMapping("/{tattooId}")
     public ResponseDto updateTattoo(@PathVariable("tattooId") Long tattooId,
                                     @RequestPart("tattooInfo") @Valid UpdateTattooReqDto updateTattooReqDto,
-                                    @RequestPart("images") List<MultipartFile> images,
+                                    @RequestPart(name = "images", required = true) List<MultipartFile> images,
                                     @UserId Long userId) {
         return ResponseUtil.SUCCESS("타투 수정 성공", this.tattooService.updateTattoo(userId, tattooId, updateTattooReqDto, images));
     }

--- a/src/main/java/com/spring/blackcat/tattoo/dto/CreateTattooDto.java
+++ b/src/main/java/com/spring/blackcat/tattoo/dto/CreateTattooDto.java
@@ -5,6 +5,7 @@ import com.spring.blackcat.common.code.TattooType;
 import lombok.Getter;
 
 import javax.validation.constraints.NotNull;
+import java.util.List;
 
 @Getter
 public class CreateTattooDto {
@@ -12,7 +13,7 @@ public class CreateTattooDto {
     TattooType tattooType;
 
     @NotNull(message = "카테고리 ID를 입력해주세요")
-    Long categoryId;
+    List<Long> categoryIds;
 
     @NotNull(message = "타투 제목을 입력해주세요")
     String title;

--- a/src/main/java/com/spring/blackcat/tattoo/dto/GetTattooResDto.java
+++ b/src/main/java/com/spring/blackcat/tattoo/dto/GetTattooResDto.java
@@ -16,8 +16,8 @@ public class GetTattooResDto extends GetTattoosResDto {
 
     //@TODO: 타투이스트 이름 추가
     public GetTattooResDto(Long id, String title, Long price, Long tattooistId, String tattooistName, String description, boolean isLiked,
-                           String address, List<String> imageUrls, TattooType tattooType, Long categoryId, int likeCount, LocalDateTime createDate, List<String> profileImageUrls) {
-        super(id, title, price, tattooistId, tattooistName, description, address, imageUrls, tattooType, categoryId);
+                           String address, List<String> imageUrls, TattooType tattooType, List<Long> categoryIds, int likeCount, LocalDateTime createDate, List<String> profileImageUrls) {
+        super(id, title, price, tattooistId, tattooistName, description, address, imageUrls, tattooType, categoryIds);
         this.likeCount = likeCount;
         this.isLiked = isLiked;
         this.createDate = createDate;

--- a/src/main/java/com/spring/blackcat/tattoo/dto/GetTattoosResDto.java
+++ b/src/main/java/com/spring/blackcat/tattoo/dto/GetTattoosResDto.java
@@ -18,5 +18,5 @@ public class GetTattoosResDto {
     private String address;
     private List<String> imageUrls;
     private TattooType tattooType;
-    private Long categoryId;
+    private List<Long> categoryIds;
 }


### PR DESCRIPTION
## 👉🏻 PR 내용 (어떤 부분이 달라졌는지 알려주세요!)
- 포스트 <-> 카테고리 관계 수정(M:N. 관계 테이블 추가)
- 타투 등록 및 수정 시 카테고리ID 여러개 받게 수정
- 타투 조회 시 카테고리ID 여러 개 내려주게 수정

## 👉🏻 중점적으로 봐주었으면 하는 부분
- 관계 설정
- tattoo.getCategoryPosts() 이거 왜 안먹는지(타투 등록 시 Post의 categoryPosts에 추가해주는데)
- DB 구조의 변경으로 카테고리쪽에도 수정할 부분 있음
- 
